### PR TITLE
Specify the useExternalCss config into the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ tarteaucitron.init({
 
     "removeCredit": false, /* Remove credit link */
     "moreInfoLink": true, /* Show more info link */
+    "useExternalCss": false /* If false, the tarteaucitron.css file will be loaded */
 
     //"cookieDomain": ".my-multisite-domaine.fr" /* Shared cookie for subdomain website */
 });


### PR DESCRIPTION
The new configuration variable has been added to the README.md

By default, it is set to false.
If set to true, the local tarteaucitron.css file will not be loaded.

The name of the config might not be self explanatory. I would have recommended changing it to "loadLocalCss". (with true by default)